### PR TITLE
Fix build on no_std

### DIFF
--- a/skrifa/src/outline/hint.rs
+++ b/skrifa/src/outline/hint.rs
@@ -9,6 +9,10 @@ use super::{
 };
 use crate::alloc::{boxed::Box, vec::Vec};
 
+#[cfg(feature = "libm")]
+#[allow(unused_imports)]
+use core_maths::CoreFloat;
+
 /// Configuration settings for a hinting instance.
 #[derive(Clone, Default, Debug)]
 pub struct HintingOptions {


### PR DESCRIPTION
Resolves the review comment I left on https://github.com/googlefonts/fontations/pull/1496 (and makes the CI pass) by using the `CoreFloat` traits to implement the `round` method without the standard library.